### PR TITLE
Don't resolve profile's display name when accessing API

### DIFF
--- a/classes/Router.php
+++ b/classes/Router.php
@@ -566,7 +566,7 @@ class Router {
         if ($location[1] == "profile" && isset($location[2])) {
             $displayNames = Cache::get("boardnames");
             $id = $location[2];
-            if (is_numeric($id) && strlen($id) == 17) {
+            if (is_numeric($id) && strlen($id) == 17 && !(isset($location[3]) && $location[3] == "json")) {
                 if ($displayNames[$location[2]]["useInURL"]) {
                     header("Location: /profile/" . $displayNames[$location[2]]["displayName"]);
                     exit;


### PR DESCRIPTION
Allows to retrieve JSON data by Steam id.
Example: https://board.iverb.me/profile/76561198042058270/json