### PR TITLE
Font replacement (WIP)

### DIFF
--- a/public/js/chart.js
+++ b/public/js/chart.js
@@ -166,7 +166,7 @@ function drawActivityChart(activityByDate, beginDate, endDate, $element, resize)
             },
             barColors: ['#2f96d1'],
             hideHover: 'auto',
-            gridTextFamily: "Segoe UI",
+            gridTextFamily: "Open Sans",
             gridTextColor: "#777"
         });
     }

--- a/public/style/style.css
+++ b/public/style/style.css
@@ -107,7 +107,7 @@ a:hover, a:focus {
     position: absolute;
     display: table;
     margin-right: 45px;
-    min-width: 325px;
+    min-width: 340px;
 }
 #header_right #userinfo{
     top: 20px;
@@ -1008,23 +1008,23 @@ body > #youtube #ytplayer {
     padding-top: 5px;
 }
 #profile .global-stats .block-container.wr {
-    width: 13%;
+    width: 14%;
 }
 #profile .global-stats .block-container.oldnew {
-    width: 19%;
+    width: 20%;
 }
 #profile .global-stats .block-container.oldnew .number {
     font-size:25px;
     vertical-align: top;
 }
 #profile .global-stats .block-container.average {
-    width: 16%;
+    width: 17%;
 }
 #profile .global-stats .block-container.bestworst {
-    width: 16%;
+    width: 17%;
 }
 #profile .global-stats .block-container.ranks {
-    width: 15%;
+    width: 16%;
 }
 #profile .global-stats .block-container.bestworst .title{
     width: 116px;

--- a/public/style/style.css
+++ b/public/style/style.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css?family=Open+Sans');
 @font-face{
     font-family: 'Aperture';
     src: url('/style/din1451alt.eot');
@@ -11,26 +12,26 @@ body {
     width: 100%;
     padding: 0;
     margin: 0;
-    font-family: Segoe UI;
+    font-family: 'Open Sans', sans-serif;
     font-size: 12px;
     min-width: 1115px;
     /*min-width: 1319px;*/
 }
 label {
     display: block;
-    font-family: Segoe UI;
+    font-family: 'Open Sans', sans-serif;
     color: #4b4b4b;
 }
 input, select {
     display: block;
-    font-family: Segoe UI;
+    font-family: 'Open Sans', sans-serif;
     background: #fdfdfd;;
     color: #000;
     font-weight: normal;
 }
 input[type=text] {
     height: 27px;
-    font-family: Segoe UI;
+    font-family: 'Open Sans', sans-serif;
     font-size: 11px;
     border: 1px solid #c2cbd0;
     background: #fdfdfd;;
@@ -136,7 +137,7 @@ a:hover, a:focus {
     margin-top: -7px;
 }
 #navigation .nav_button, #navigation > .nav_dropdown {
-    font-family: Segoe UI;
+    font-family: 'Open Sans', sans-serif;
     font-size: 15px;
     /*font-weight: bold;*/
     /*letter-spacing: -0.5px;*/
@@ -287,7 +288,7 @@ a:hover, a:focus {
 }
 #welcome {
     float: left;
-    font-family: Segoe UI;
+    font-family: 'Open Sans', sans-serif;
     font-size: 12px;
     color: #333;
     text-align: right;
@@ -323,7 +324,7 @@ a:hover, a:focus {
     margin-top: 55px;
     color: #e1e1e1;
     font-size: 20px;
-    font-family: Segoe UI;
+    font-family: 'Open Sans', sans-serif;
     font-weight: bold;
     text-shadow: 0px 0px 3px #000000;
     filter: dropshadow(color=#000000, offx=0, offy=0);
@@ -415,7 +416,7 @@ a:hover, a:focus {
 }
 #chambers .chamber_scores {
     width: 100%;
-    font-family: Segoe UI;
+    font-family: 'Open Sans', sans-serif;
     font-size: 12px;
     /*text-transform: uppercase;*/
     /*font-family: Aperture;*/
@@ -518,7 +519,7 @@ a:hover, a:focus {
     left: 5px;
 }
 #about {
-    font-family: Segoe UI;
+    font-family: 'Open Sans', sans-serif;
     margin: 30px 0px 0px 42px;
 }
 #about .largeTitle {
@@ -593,7 +594,7 @@ a:hover, a:focus {
     margin-top: -56px;
     height: 56px;
     clear: both;
-    font-family: Tahoma, Segoe UI;
+    font-family: Tahoma, 'Open Sans', sans-serif;
     font-size: 11px;
     color: #4c4c4c;
     padding: 0 20px;
@@ -695,7 +696,7 @@ a:hover, a:focus {
     font-weight: bold;
     cursor: pointer;
     font-size: 11px;
-    font-family: Tahoma, Segoe UI;
+    font-family: Tahoma, 'Open Sans', sans-serif;
     color: #7b7b7b;
 }
 #changelog #firstentry, .datatable #firstentry {
@@ -834,7 +835,7 @@ a:hover, a:focus {
     text-align: left;
 }
 #changelog .morris-hover, #profile .morris-hover, #chamber .morris-hover  {
-    font-family: Segoe UI;
+    font-family: 'Open Sans', sans-serif;
     font-size: 12px;
     color: #444;
     padding: 10px;
@@ -843,7 +844,7 @@ a:hover, a:focus {
      white-space: nowrap;
 }
 #profile .morris-hover table, #changelog .morris-hover table   {
-    font-family: Segoe UI;
+    font-family: 'Open Sans', sans-serif;
     font-size: 12px;
     color: inherit;
     white-space: nowrap;
@@ -907,7 +908,7 @@ body > #youtube #ytplayer {
 
 #editProfile {
     margin: 20px 0px 0px 22px;
-    font-family: Segoe UI;
+    font-family: 'Open Sans', sans-serif;
 }
 #editProfile .normalcontent {
     font-size: 12px;
@@ -928,7 +929,7 @@ body > #youtube #ytplayer {
     margin: 30px auto;
     padding: 10px;
     /*overflow: auto;*/
-    /*font-family: Segoe UI, Helvetica, sans-serif;*/
+    /*font-family: 'Open Sans', sans-serif, Helvetica, sans-serif;*/
     box-sizing: content-box;
 }
 #profile .userinformation {
@@ -1677,7 +1678,7 @@ body > #youtube #ytplayer {
 
 #chamber .entry > *  {
     float: left;
-    font-family: Segoe UI;
+    font-family: 'Open Sans', sans-serif;
     color: #4A4A4A;
     font-size: 14px;
     line-height: 42px;
@@ -1823,7 +1824,7 @@ body > #youtube #ytplayer {
     -webkit-user-select: none;
     vertical-align: middle;
     font-size: 13px;
-    font-family: Segoe UI;
+    font-family: 'Open Sans', sans-serif;
     text-transform: none;
     line-height: 24px;
 }

--- a/views/chamber.phtml
+++ b/views/chamber.phtml
@@ -190,7 +190,7 @@
         gridTextSize: 11,
         lineColors: ['#2f96d1'],
         hideHover: 'auto',
-        gridTextFamily : "Segoe UI",
+        gridTextFamily : "Open Sans",
         gridTextColor: "#777",
         smooth: false
     });

--- a/views/parts/navigation.phtml
+++ b/views/parts/navigation.phtml
@@ -82,7 +82,7 @@
 <div class="nav_dropdown">
     <div id="aperture_icon" class="nav_icon"></div>
     <div class="btnLabel">More</div>
-    <ul style="width:145px">
+    <ul style="width:155px">
       <li class="nav_dropdown">
         <a href="http://www.speedrun.com/Portal_2" target="_blank" style="height: 29px">
             <div class="nav_icon" style="background: url('/images/running.png'); background-size: 29px 29px;"></div>


### PR DESCRIPTION
**Summary**
Replace `Segoe UI` with `Open Sans`.


**Motivation**
Since `Segoe UI` is basically a "Windows only" font people on other operating systems would appreciate to view the site in its intended state.

**Tests**

|Chrome 70 (Linux)|Firefox 63 (Linux)|Chrome 70 (Windows)|Firefox 63 (Windows)|
|:-:|:-:|:-:|:-:|
|✔|✔|✖|✖|

**Caveats**
Adjusted `style.css` a bit for profile statistics, might have to change it again when someone gets a 3-digit world record count number but this will never happen, right?
Also Google claims that their fonts API doesn't affect loading times. I didn't do any tests about this.