### PR TITLE
New changelog parameters

### DIFF
--- a/classes/Leaderboard.php
+++ b/classes/Leaderboard.php
@@ -477,8 +477,8 @@ class Leaderboard
                 : "NULL";
 
             Debug::log("Inserting change. Player: ".$change["profileNumber"]." Map: ".$change["mapId"]." Score: ".$change["score"]);
-            Database::query("INSERT INTO changelog(id, profile_number, score, map_id, wr_gain, previous_id, pre_rank)
-              VALUES (NULL, '" . $change["profileNumber"] . "','" . $change["score"] . "','" . $change["mapId"] . "','" . $wr . "', ". $previousId .", ".$preRank.")
+            Database::query("INSERT INTO changelog(id, profile_number, score, map_id, previous_id, pre_rank)
+              VALUES (NULL, '" . $change["profileNumber"] . "','" . $change["score"] . "','" . $change["mapId"] . "', ". $previousId .", ".$preRank.")
             ");
 
             $id = Database::getMysqli()->insert_id;
@@ -700,7 +700,7 @@ class Leaderboard
         }
 
         $whereHasDate = ($param["hasDate"] != "" && $param["hasDate"] == 0) ? "time_gained IS NULL AND " : "time_gained IS NOT NULL AND ";
-        $whereWr = ($param["wr"] != "") ? "wr_gain = '{$param["wr"]}' AND " : "";
+        $whereWr = ($param["wr"] != "" && $param["wr"] == 1) ? "post_rank = '1' AND " : "";
         $whereBanned = ($param["banned"] != "") ? "banned = '{$param["banned"]}' AND " : "";
         $whereId = ($param["id"] != "") ? "id = '{$param["id"]}' AND " : "";
         $wherePostRank = ($param["postRank"] != "") ? "post_rank = '{$param["postRank"]}' AND " : "";
@@ -709,7 +709,7 @@ class Leaderboard
         $isOnWallOfShame= ($param['wos'] == "1") ? 1 : 0;
 
         $changelog_data = Database::query("SELECT IFNULL(usersnew.boardname, usersnew.steamname) AS player_name, usersnew.avatar, ch.profile_number,
-                                            ch.score, ch.id, ch.pre_rank, ch.post_rank, ch.wr_gain, ch.time_gained, ch.has_demo as hasDemo, ch.youtube_id as youtubeID, ch.note,
+                                            ch.score, ch.id, ch.pre_rank, ch.post_rank, ch.time_gained, ch.has_demo as hasDemo, ch.youtube_id as youtubeID, ch.note,
                                             ch.banned, ch.submission,
                                             ch_previous.score as previous_score,
                                             maps.name as chamberName, chapters.id as chapterId, maps.steam_id AS mapid
@@ -756,6 +756,7 @@ class Leaderboard
             $row["pre_points"] = null;
             $row["post_point"] = null;
             $row["point_improvement"] = null;
+            $row["wr_gain"] = $row["post_rank"] == 1 ? 1 : 0;
 
             if ($row["previous_score"] != NULL) {
                 $row["improvement"] = ($row["previous_score"] - $row["score"]);
@@ -1156,8 +1157,8 @@ class Leaderboard
             ? $oldChamberBoard[$profileNumber]["scoreData"]["changelogId"]
             : "NULL";
 
-        Database::query("INSERT INTO changelog(id, profile_number, score, map_id, wr_gain, previous_id, pre_rank, submission, note)
-              VALUES (NULL, '" . $profileNumber . "','" . $score . "','" . $chamber . "','" . $wr . "', ". $previousId .", ".$preRank.", 1, '".$comment."')
+        Database::query("INSERT INTO changelog(id, profile_number, score, map_id, previous_id, pre_rank, submission, note)
+              VALUES (NULL, '" . $profileNumber . "','" . $score . "','" . $chamber . "', ". $previousId .", ".$preRank.", 1, '".$comment."')
             ");
 
         $id = Database::getMysqli()->insert_id;

--- a/classes/Leaderboard.php
+++ b/classes/Leaderboard.php
@@ -662,6 +662,7 @@ class Leaderboard
         , "wr" => ""
         , "postRank" => ""
         , "preRank" => ""
+        , "top" => ""
         , "dateStart" => ""
         , "dateEnd" => ""
         , "banned" => ""
@@ -705,6 +706,7 @@ class Leaderboard
         $whereId = ($param["id"] != "") ? "id = '{$param["id"]}' AND " : "";
         $wherePostRank = ($param["postRank"] != "") ? "post_rank = '{$param["postRank"]}' AND " : "";
         $wherePreRank = ($param["preRank"] != "") ? "pre_rank = '{$param["preRank"]}' AND " : "";
+        $whereTopRank = ($param["top"] != "") ? "post_rank <= '{$param["top"]}' AND " : "";
 
         $isOnWallOfShame= ($param['wos'] == "1") ? 1 : 0;
 
@@ -724,6 +726,7 @@ class Leaderboard
                                                             . $whereId . " "
                                                             . $wherePostRank . " "
                                                             . $wherePreRank . " "
+                                                            . $whereTopRank . " "
                                                             . $whereDateStart . " "
                                                             . $whereDateEnd . "
                                                     map_id LIKE '%{$param['chamber']}%' 

--- a/classes/Router.php
+++ b/classes/Router.php
@@ -726,6 +726,7 @@ class Router {
             , "wr" => ""
             , "postRank" => ""
             , "preRank" => ""
+            , "top" => ""
             , "dateStart" => ""
             , "dateEnd" => ""
             , "demo" => ""

--- a/classes/Router.php
+++ b/classes/Router.php
@@ -716,17 +716,26 @@ class Router {
     private function prepareChangelogParams($params)
     {
         $result = array(
-        "chamber" => ""
-        , "chapter" => ""
-        , "boardName" => "" 
-        , "profileNumber" => ""
-        , "type" => "" , "sp" => "1", "coop" => "1"
-        , "wr" => ""
-        , "demo" => ""
-        , "yt" => ""
-        , "maxDaysAgo" => ""
-        , "submission" => ""
-        , "banned" => "");
+            "chamber" => ""
+            , "chapter" => ""
+            , "boardName" => "" 
+            , "profileNumber" => ""
+            , "type" => ""
+            , "sp" => ""
+            , "coop" => ""
+            , "wr" => ""
+            , "postRank" => ""
+            , "preRank" => ""
+            , "dateStart" => ""
+            , "dateEnd" => ""
+            , "demo" => ""
+            , "yt" => ""
+            , "maxDaysAgo" => ""
+            , "submission" => ""
+            , "banned" => ""
+            , "wos" => ""
+            , "id" => ""
+            , "hasDate" => "");
 
         $changelog_post = array();
         foreach ($params as $key => $val) {

--- a/views/changelog.phtml
+++ b/views/changelog.phtml
@@ -97,7 +97,7 @@
         <div style="font-size: 20px; margin: auto; width: 100%; text-align: center; color: #888;">
             <i class="fa fa-times" style="padding-right: 10px"></i>No scores found
         </div>
-    <?php elseif (count($activity) > 0): ?>
+    <?php elseif (count($view->changelog) > 0): ?>
         <div class = 'activity'>
             <div id= 'changelogActivity' style= 'height: 175px;'>
                 <i class="fa fa-circle-o-notch fa-spin fa-fw loading"></i>
@@ -148,44 +148,20 @@
 
     $(document).ready(function() {
 
-        // $(".rank").each(function() {
-        //     //pointsOnHover($(this), $(this).text());
-
-        //     if ($(this).find("i").length) {
-        //         rank = 1;
-        //     }
-        //     else {
-        //         rank = parseInt($(this).text());
-        //     }
-
-        //     var points = Math.max(1,  Math.pow(200 - (rank - 1), 2) / 200);
-        //     points = Math.round(points * 10) / 10;
-
-        //     if (!isNaN(rank)) {
-
-        //         var title;
-        //         if (points == 1)
-        //             title = points + " point";
-        //         else
-        //             title = points + " points";
-
-        //         $(this).tooltip({
-        //             trigger: 'manual',
-        //             placement: 'top',
-        //             title: title
-        //         });
-
-        //         $(this).hover(function() {
-        //             $(this).tooltip('show');
-        //         }, function() {
-        //             $(this).tooltip('hide');
-        //         });
-        //     }
-        // });
-
         $(".entry").each(function() {
-            
+
             var $entry = $(this);
+
+        <?php if(SteamSignIn::loggedInUserIsAdmin()): ?>
+            var $date = $entry.find(".date .dateTime");
+            $date.tooltip({trigger: 'manual', title: "ID " + this.id });
+            $date.hover(function() {
+                $(this).tooltip('show');
+            }, function() {
+                $(this).tooltip('hide');
+            });
+        <?php endif; ?>
+
             var $preRank = $entry.find(".previousscore .rank");
             var $postRank = $entry.find(".newscore .rank");
             var $rankDiff = $entry.find(".rankImprovement")
@@ -199,10 +175,11 @@
             var prePoints = getPointsFromRank(preRank);
             var postPoints = getPointsFromRank(postRank)
             var pointDiff = (postPoints - prePoints);
+            var hasGained = pointDiff > 0;
 
             if (!isNaN(pointDiff) && pointDiff != 0) {
-                pointDiff = Math.round(pointDiff * 10) / 10;
-                var title = "gained " + pointDiff + " " + (pointDiff == 1 ?  + "point" : "points");
+                pointDiff = Math.abs(Math.round(pointDiff * 10) / 10);
+                var title = (hasGained ? "gained " : "lost ") + pointDiff + " " + (pointDiff == 1 ?  + "point" : "points");
                 $rankDiff.tooltip({trigger: 'manual', title: title });
                 $rankDiff.hover(function() {
                     $(this).tooltip('show');
@@ -257,9 +234,13 @@
         });
 
         var activityByScore = getActivityByScore(<?=json_encode($activity)?>);
+        var activityChart = $("#changelogActivity");
         if (Object.keys(activityByScore).length > 0) {
             var activityByDate = getActivityByDate(activityByScore);
-            drawActivityChart(activityByDate, localizeDate(getDateFirstChange(activityByDate)), getCurrentLocalDate(), $("#changelogActivity"));
+            drawActivityChart(activityByDate, localizeDate(getDateFirstChange(activityByDate)), getCurrentLocalDate(), activityChart);
+        } else {
+            activityChart.hide();
+            document.querySelector('#filters').style.marginBottom = "60px";
         }
     });
 

--- a/views/changelog.phtml
+++ b/views/changelog.phtml
@@ -13,7 +13,7 @@
     <div id="filters">
         <div id="filter_instructions_lol">Use these filters to display the changelog you want</div>
         <div id="filter_options">
-            <form name="filters" action="/changelog" method="get">
+            <form name="filters" action="/changelog" method="get" onsubmit="clearEmptyParams(this);">
                 <div style="float: left;" class="input">
                     <label for="nickname">Nickname</label>
                     <input type="text" name="boardName" value="<?=$param['boardName'];?>">
@@ -136,6 +136,15 @@
     <?php endif; ?>
     </div>
 <script>
+    function clearEmptyParams(form) {
+        var inputs = form.querySelectorAll('input,select');
+        var input;
+        for (var i = 0; input = inputs[i]; ++i) {
+            if (input.getAttribute('name') && (!input.value || input.value === "")) {
+                input.setAttribute('name', '');
+            }
+        }
+    }
 
     $(document).ready(function() {
 

--- a/views/util/ChangelogView.php
+++ b/views/util/ChangelogView.php
@@ -7,7 +7,7 @@ class ChangelogView
 
     static function getEntry($board, $key, $page, $entry) { ?>
         <?php $val = $board[$key] ?>
-        <div class="entry" <?php
+        <div class="entry" id="<?=$val["id"]?>" <?php
             if (strtotime($val["time_gained"]) != strtotime(self::$lastDate)) {
                 self::$oddDateEntry = !self::$oddDateEntry;
             }


### PR DESCRIPTION
**Summary**
More parameters to filter the changelog.

**API Overview**

|Parameter|Description|Example|
|---|---|---|
|`postRank`|Player post rank.|`?postRank=2`|
|`preRank`|Player pre rank.|`?preRank=3`|
|`dateStart`|Date range start.|`?dateStart=2013-01-01`|
|`dateEnd`|Date range end.|`?dateEnd=2018-01-01`|
|`hasDate`|Entry has a known date.|`?hasDate=1`|
|`id`|Changelog id.|`?id=1337`|
|`wos`|Player is banned.|`?wos=1`|
|`top`|Top x post rank.|`?top=10`|

**Open Questions**
~~Table column `wr_gain` doesn not seem to have any purpose except filtering the changelog by `wr` parameter. Wouldn't it make more sense to filter world records by `post_rank`? This would eliminate the bug where rank x or banned scores [would still show up as WRs](https://board.iverb.me/changelog?boardName=&chamber=47452&wr=1) in the changelog and other unnecessary logic like in PR #3.~~
Edit: `wr_gain` now depends on `postRank`.

Here are some alternative names for date range:
- `startDate` and `endDate`
- `fromDate` and `toDate`

~~Also `hasDate` seems to be hidden on purpose? This PR will expose it though.~~

**Caveats**
Empty form parameters won't be part of the query anymore:

*Before*
`https://board.iverb.me/changelog?boardName=&profileNumber=&chapter=&chamber=&sp=1&coop=1&wr=1&demo=&yt=&submission=`
*After*
`https://board.iverb.me/changelog?wr=1`

**Other Changes**
- Changelog id tool tip  (useful for admins)
- Tooltip for `lost x points`