### PR TITLE
Separate glitch and no-glitch maps (WIP)

### DIFF
--- a/classes/Leaderboard.php
+++ b/classes/Leaderboard.php
@@ -127,7 +127,7 @@ class Leaderboard
     //TODO: generalize map list to id's instead of steam time id's
     public static function getMaps()
     {
-        $data = Database::query("SELECT maps.id, steam_id, is_coop, name, chapter_id, chapters.chapter_name, is_public, lp_id
+        $data = Database::query("SELECT maps.id, steam_id, is_coop, name, chapter_id, chapters.chapter_name, is_public, lp_id, is_frozen, is_glitched, rel_id
                             FROM maps
                             INNER JOIN chapters ON maps.chapter_id = chapters.id
                             ORDER BY  is_coop, maps.id");
@@ -146,6 +146,9 @@ class Leaderboard
             $maps["maps"][$row["steam_id"]]["isPublic"] = $row["is_public"];
             $maps["maps"][$row["steam_id"]]["mapName"] = $row["name"];
             $maps["maps"][$row["steam_id"]]["chapterId"] = $row["chapter_id"];
+            $maps["maps"][$row["steam_id"]]["is_frozen"] = $row["is_frozen"];
+            $maps["maps"][$row["steam_id"]]["is_glitched"] = $row["is_glitched"];
+            $maps["maps"][$row["steam_id"]]["rel_id"] = $row["rel_id"];
 
             if ($row["lp_id"] != NULL) {
                 $maps["lpMaps"][$row["lp_id"]] = $row["steam_id"];
@@ -769,8 +772,13 @@ class Leaderboard
 
     public static function makeChamberPointBoard($board)
     {
+        $maps = Cache::get("maps");
         foreach ($board as $chapter => $chapterData) {
             foreach ($chapterData as $map => $mapData) {
+                if ($maps["maps"][$map]["is_frozen"]) {
+                    continue;
+                }
+
                 foreach ($mapData as $user => $userScoreData) {
                     $pointBoard[$chapter][$map][$user]["userData"] = $userScoreData["userData"];
 

--- a/classes/User.php
+++ b/classes/User.php
@@ -326,6 +326,7 @@ class User {
     }
 
     public function getChamberData($board) {
+        $maps = Cache::get("maps");
         $times = NULL;
         $times["numWRs"] = 0;
         $times["rankSum"] = 0;
@@ -349,29 +350,36 @@ class User {
                         $times["numYoutubeVideos"]++;
                     }
 
-                    $times["rankSum"] += $scoreData["playerRank"];
-                    $times["mapCount"]++;
+                    if (!$maps["maps"][$map]["is_frozen"]) {
+                        $times["rankSum"] += $scoreData["playerRank"];
+                        $times["mapCount"]++;
 
-                    if ($times["worstRank"] == NULL) {
-                        $times["bestRank"]["scoreData"] = $scoreData;
-                        $times["worstRank"]["scoreData"] = $scoreData;
-                        $times["bestRank"]["map"] = $map;
-                        $times["worstRank"]["map"] = $map;
-                    }
-                    else {
-                        if ($times["worstRank"]["scoreData"]["playerRank"] == $scoreData["playerRank"]) {
-                            $times["worstRank"]["map"] = "several chambers";
+                        $entryKeys = array_keys($mapData);
+                        if ($mapData[$entryKeys[0]]["scoreData"]["score"] == $scoreData["score"]) {
+                            $times["numWRs"]++;
                         }
-                        if ($times["bestRank"]["scoreData"]["playerRank"] == $scoreData["playerRank"]) {
-                            $times["bestRank"]["map"] = "several chambers";
-                        }
-                        if ($times["worstRank"]["scoreData"]["playerRank"] < $scoreData["playerRank"]) {
+
+                        if ($times["worstRank"] == NULL) {
+                            $times["bestRank"]["scoreData"] = $scoreData;
                             $times["worstRank"]["scoreData"] = $scoreData;
+                            $times["bestRank"]["map"] = $map;
                             $times["worstRank"]["map"] = $map;
                         }
-                        if ($times["bestRank"]["scoreData"]["playerRank"] > $scoreData["playerRank"]) {
-                            $times["bestRank"]["scoreData"] = $scoreData;
-                            $times["bestRank"]["map"] = $map;
+                        else {
+                            if ($times["worstRank"]["scoreData"]["playerRank"] == $scoreData["playerRank"]) {
+                                $times["worstRank"]["map"] = "several chambers";
+                            }
+                            if ($times["bestRank"]["scoreData"]["playerRank"] == $scoreData["playerRank"]) {
+                                $times["bestRank"]["map"] = "several chambers";
+                            }
+                            if ($times["worstRank"]["scoreData"]["playerRank"] < $scoreData["playerRank"]) {
+                                $times["worstRank"]["scoreData"] = $scoreData;
+                                $times["worstRank"]["map"] = $map;
+                            }
+                            if ($times["bestRank"]["scoreData"]["playerRank"] > $scoreData["playerRank"]) {
+                                $times["bestRank"]["scoreData"] = $scoreData;
+                                $times["bestRank"]["map"] = $map;
+                            }
                         }
                     }
 
@@ -391,11 +399,6 @@ class User {
                                 $times["newestScore"]["map"] = $map;
                             }
                         }
-                    }
-
-                    $entryKeys = array_keys($mapData);
-                    if ($mapData[$entryKeys[0]]["scoreData"]["score"] == $scoreData["score"]) {
-                        $times["numWRs"]++;
                     }
 
                     $times["chamber"][$chapter][$map]["WRDiff"] = $this->getWRDiff($mapData);

--- a/public/style/style.css
+++ b/public/style/style.css
@@ -1758,6 +1758,11 @@ body > #youtube #ytplayer {
     bottom: 10px;
     left: 10px;
 }
+#chamber .controls.topright.below {
+    position: absolute;
+    top: 41px;
+    right: 10px;
+}
 #chamber .controls.topright {
     position: absolute;
     top: 10px;

--- a/views/chamber.phtml
+++ b/views/chamber.phtml
@@ -3,6 +3,9 @@
 <?php $chapter = $mapInfo["chapters"][$mapInfo["maps"][$GLOBALS["chamberID"]]["chapterId"]]["chapterName"]; ?>
 <?php $map = $mapInfo["maps"][$GLOBALS["chamberID"]]["mapName"]; ?>
 <?php $isPublic = $mapInfo["maps"][$GLOBALS["chamberID"]]["isPublic"]; ?>
+<?php $isFrozen = $mapInfo["maps"][$GLOBALS["chamberID"]]["is_frozen"]; ?>
+<?php $isGlitched = $mapInfo["maps"][$GLOBALS["chamberID"]]["is_glitched"]; ?>
+<?php $relativeId = $mapInfo["maps"][$GLOBALS["chamberID"]]["rel_id"]; ?>
 <?php $wrs = Leaderboard::getChangelog(array("chamber" => $GLOBALS["chamberID"], "wr" => "1", "banned" => 0));?>
 <?php $youtubeIDs = Cache::get("youtubeIDs".$GLOBALS["chamberID"])?>
 <?php include("util/PageGenerator.php") ?>
@@ -12,10 +15,9 @@
     <div class="chamberview" style="background-image: url('/images/chambers_full/<?=$GLOBALS["chamberID"];?>.jpg')">
         <div class="chamberinfo">
             <div class="chamberchaptername"><?=$chapter;?></div>
-            <?php if($isPublic == "1"): ?>
-                <a href="http://steamcommunity.com/stats/Portal2/leaderboards/<?=$GLOBALS["chamberID"];?>" target="_blank" class="chamberchambername"><?=$map;?></a>
-            <?php endif; ?>
-            <?php if($isPublic == "0"): ?>
+            <?php if($isPublic > 0): ?>
+                <a href="https://steamcommunity.com/stats/Portal2/leaderboards/<?=$GLOBALS["chamberID"];?>" target="_blank" class="chamberchambername"><?=$map;?></a>
+            <?php else:?>
                 <span class="chamberchambername"><?=$map;?></span>
             <?php endif; ?>
             <div class="controls topright">
@@ -26,14 +28,24 @@
                     </a>
                 </div>
             </div>
+            <?php if($relativeId): ?>
+                <div class="controls topright below">
+                    <div class="button linkButton chamberHistoryButton">
+                        <a href="/chamber/<?=$relativeId?>" class="name">
+                            <i class="fa fa-fw fa-arrows-h" aria-hidden="true"></i>
+                            <?=$isGlitched?"Switch n/G":"Switch w/G"?>
+                        </a>
+                    </div>
+                </div>
+            <?php endif; ?>
+            <?php if($isPublic == 1): ?>
             <div class="controls topleft">
-                <?php if($isPublic): ?>
                     <div class="button standardButton fetchChamberScoresButton">
                         <i class="fa fa-fw fa-refresh" aria-hidden="true"></i>
                         Fetch new scores
                     </div>
-                <?php endif; ?>
             </div>
+                <?php endif; ?>
             <div class="controls left">
                 <div class="button standardButton wrHistoryButton">
                     <span class="name">
@@ -63,11 +75,20 @@
             </div>
         </div>
     </div>
-    <?php if($isPublic == "0"): ?>
+    <?php if($isPublic == 2): ?>
+        <div class="not-public-chambers">
+            <span class="notification">
+              This chamber does not sync automatically with the official Steam leaderboard.
+              You therefore need to submit any scores you obtain for this chamber manually via your profile.
+              Note that runs here are done without the use of moving portal physics.
+            </span>
+            <span class="close-btn"></span>
+        </div>
+    <?php elseif($isPublic == 0): ?>
         <div class="not-public-chambers">
             <span class="notification">
               This chamber is not available through official Steam leaderboard pages, but is accessible by modifying the game's
-              internal map list. A tutorial for doing this can be found <b><a href="http://youtu.be/8mtyKGh_e-w?t=18m30s" target="_blank">here</a></b>.
+              internal map list. A tutorial for doing this can be found <b><a href="https://youtu.be/8mtyKGh_e-w?t=18m30s" target="_blank">here</a></b>.
               Note that unlike an official chamber, scores you obtain for this chamber are not automatically synced to this website.
               You therefore need to submit any scores you obtain for this chamber manually via your profile.
             </span>
@@ -99,7 +120,11 @@
         $(".entries.pages").css("height", Math.min(25, <?=count($mapData)?>) * 43);
 
         $(".rank").each(function() {
+            <?php if (!$isFrozen): ?>
             pointsOnHover($(this), parseInt($(this).text()), { placement: 'left' });
+            <?php else:?>
+                pointsOnHover($(this), 0, { placement: 'left' });
+            <?php endif;?>
         });
 
         $(".fa.fa-pencil").each(function() {

--- a/views/chambers.phtml
+++ b/views/chambers.phtml
@@ -22,6 +22,9 @@
                 <?php $mapData = $view->board[$chapter][$map] ?>
                 <?php $mapName = $mapInfo["maps"][$map]["mapName"]?>
                 <?php $isPublic =  $mapInfo["maps"][$map]["isPublic"]?>
+                <?php if ($mapInfo["maps"][$map]["is_glitched"]) {
+                    continue;
+                }?>
                 <div class="chamber">
                     <div class="chamberimage" onclick="goToChamber(event, <?=$map;?>)" style="background: url('/images/chambers/<?=$map;?>.jpg'); background-size: cover">
                         <div class="chambertitle">
@@ -29,8 +32,8 @@
                             <div class="titlebg"><a href="/chamber/<?=$map;?>"><?=$mapName?></a></div>
                         </div>
                         <div class="chamber_icons_left">
-                            <?php if($isPublic == "1"): ?>
-                                <a href="<?php echo "http://steamcommunity.com/stats/Portal2/leaderboards/".$map;?>" class="icons" target="_blank">
+                            <?php if($isPublic > 0): ?>
+                                <a href="<?php echo "https://steamcommunity.com/stats/Portal2/leaderboards/".$map;?>" class="icons" target="_blank">
                                      <span class="icons steamLink fa-stack">
                                           <i class="fa fa-square fa-stack-2x"></i>
                                           <i class="fa fa-steam-square fa-stack-2x"></i>


### PR DESCRIPTION
**Summary**
This PR separates scores which use the moving portals glitch.

![showcase-gif](https://user-images.githubusercontent.com/16884507/61216536-db780480-a70d-11e9-9174-d6914e98857b.gif)

**Overview**

|Column|Usage|Description|
|---|---|---|
|`is_glitched`|Map uses the moving portals glitch.|Map won't appear in the chambers page.|
|`rel_id`|Map ID which links to another map.|Required for the button in chamber page which links to the glitch or no-glitch chamber page.|
|`is_public=2`|Map is not syncing with Steam and requires manual submission.|Hint in chamber page.|
|`is_frozen`|Map will be ignored in certain profile stats and point calculation.|Glitched maps and maps which are not competitive enough or too easy to play e.g. Propulsion Catch.|

**TODO**
- Database
  - Add the new columns
  - Add new `Wall Button` and `Propulsion Catch` maps
  - Move old map scores before the discovery of a glitch route has been found to the new maps
  - Set `is_public` to 2
  - Rename old maps which adds an indicator that they use the glitch e.g. "Wall Button w/G"
  - Set `is_glitched` and `is_frozen` to 1 for these maps
  - Set `rel_id` on all four maps
  - Fix IDs so a glitch map will be sorted below the no-glitch map in profiles
- Fix point calculation in changelog and timeboard calculation for `ìs_frozen` maps
- Update rules