### PR TITLE
Fix images in webhooks

### DIFF
--- a/classes/Discord.php
+++ b/classes/Discord.php
@@ -46,7 +46,7 @@ class Discord {
                 'text' => 'board.iverb.me'
             ],
             'image' => [
-                'url' => 'https://board.iverb.me/images/chambers_full/'.$data['map_id'].'.jpg'
+                'url' => 'https://raw.githubusercontent.com/iVerb1/Portal2Boards/master/public/images/chambers_full/'.$data['map_id'].'.jpg'
             ],
             'author' => [
                 'name' => $data['player'],


### PR DESCRIPTION
Apparently images will be cached once you load them within the site. Discord clients cannot access them directly but we can serve the images from this repository instead which should also reduce some load.